### PR TITLE
Remove include_bitcode setting in ios build lane

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -122,7 +122,6 @@ platform :ios do
     build_app(
       silent: true,
       include_symbols: true,
-      include_bitcode: true,
       analyze_build_time: true,
       scheme: options[:scheme],
       workspace: IOS_WORK_PATH,


### PR DESCRIPTION
Xcode 14 is deprecating default bitcode builds.
https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes#Deprecations

This commit removes the include_bitcode setting as a default for iOS builds.